### PR TITLE
small fix to the idle action and subsequent coach call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 .idea/*
 
 *.orig
+
+# InfluenceMap output file
+IMBoard

--- a/ai/STA/Action/Idle.py
+++ b/ai/STA/Action/Idle.py
@@ -27,6 +27,7 @@ class Idle(Action):
         Exécute l'arrêt
         :return: Un tuple (Pose, kick) où Pose est la position du joueur et kick est nul (on ne botte pas)
         """
-        move_destination = self.info_manager.get_player_pose(self.player_id)
+        # un None pour que le coachcommandsender envoi une command vide.
+        move_destination = None
         kick_strength = 0
         return AICommand(move_destination, kick_strength)

--- a/coach.py
+++ b/coach.py
@@ -148,7 +148,8 @@ class CoachCommandSender(object):
         return command.MoveToAndRotate(self._get_player(), p_move_destination)
 
     def _generate_empty_command(self):
-        return command.MoveToAndRotate(self._get_player(), self._get_player().pose)
+        #Envoi d'une command vide qui fait l'arrêt du robot
+        return command.Stop(self._get_player())
 
     def _get_player(self):
         return self.game_state.friends.players[self.current_player_id]

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -40,7 +40,7 @@ class TestActions(unittest.TestCase):
 
     def test_idle(self):
         self.idle = Idle(self.info_manager, self.player_id)
-        current_pose = self.info_manager.get_player_pose(self.player_id)
+        current_pose = None
         current_pose_string = "AICommand(move_destination=" + str(current_pose) + ", kick_strength=0)"
         self.assertEqual(str(Idle.exec(self.idle)), current_pose_string)
 


### PR DESCRIPTION
J'ai changer le code de l'action Idle pour quelle retourne un None au lieu de retourner la pose du joueur pour qu'il reste sur place. Aussi changer _generate_empty_command dans coachcommandsender pour qu'elle evoye réellement un command vide (command.Stop()).