### PR TITLE
Fix pour la presence de robot non-existant au coord 0,0 pour le pathfinder

### DIFF
--- a/ai/GameDomainObjects/team.py
+++ b/ai/GameDomainObjects/team.py
@@ -20,6 +20,7 @@ class Team:
     def update(self, players):
         # self._players = {}
         # self._onplay_players = {}
+        self._onplay_players = {player["id"]: self._players[player["id"]] for player in players}
         for p in players:
             # p = Player.from_dict(dict_player, team=self)
             self._players[p["id"]].update(Pose.from_dict(p["pose"]), Pose.from_dict(p["velocity"]))
@@ -39,7 +40,7 @@ class Team:
         return self._players
 
     @property
-    def onplay_player(self):
+    def onplay_players(self):
         return self._onplay_players
 
     @property

--- a/ai/executors/pathfinder_module.py
+++ b/ai/executors/pathfinder_module.py
@@ -58,14 +58,14 @@ def get_pertinent_collision_objects(commanded_player, game_state, ai_command, op
     collision_bodies = []
     gap_proxy = 250
     # FIXME: Find better name that is less confusing between self.player and player
-    for player in game_state.our_team.available_players.values():
+    for player in game_state.our_team.onplay_players.values():
         if player.id != commanded_player.id:
             if (commanded_player.pose.position - player.pose.position).norm + \
                     (ai_command.target.position - player.pose.position).norm < \
                     (ai_command.target.position - commanded_player.pose.position).norm * factor:
                 collision_bodies.append(
                     CollisionBody(player.pose.position, player.velocity.position, gap_proxy))
-    for player in game_state.enemy_team.available_players.values():
+    for player in game_state.enemy_team.onplay_players.values():
         if (commanded_player.pose.position - player.pose.position).norm + \
                 (ai_command.target.position - player.pose.position).norm < \
                 (ai_command.target.position - commanded_player.pose.position).norm * factor:


### PR DESCRIPTION
Utilise les robots des listes de team blue et yellow pour créer les obsacles. Si d'autres robots qui ne font pas partie des teams pourrait être sur le terrain et que l'on voudrait éviter ceux-ci avec le pathfinder, il faudrait les ajouter.