### PR TITLE
We no longer switch to a defensive strategy when the ball is in our side

### DIFF
--- a/ai/Algorithm/auto_play.py
+++ b/ai/Algorithm/auto_play.py
@@ -72,6 +72,24 @@ class SimpleAutoPlayState(IntEnum):
     NOT_ENOUGH_PLAYER = 21
 
 
+def our_player_is_closest():
+    our_closest_players = closest_players_to_point(GameState().ball_position, our_team=True)
+    their_closest_players = closest_players_to_point(GameState().ball_position, our_team=False)
+
+    if len(their_closest_players) == 0:
+        return True
+    if len(our_closest_players) == 0:
+        return False
+    return our_closest_players[0].distance < their_closest_players[0].distance
+
+
+def no_enemy_around_ball():
+    SAFE_DISTANCE = 1000
+    their_closest_players = closest_players_to_point(GameState().ball_position, our_team=False)
+    return len(their_closest_players) == 0 or their_closest_players[0].distance > SAFE_DISTANCE
+
+
+
 class SimpleAutoPlay(AutoPlay):
     """
         Classe simple implémentant la sélection de stratégies.
@@ -235,7 +253,7 @@ class SimpleAutoPlay(AutoPlay):
         }.get(self.last_ref_state, SimpleAutoPlayState.NORMAL_DEFENSE)
 
     def _decide_between_normal_play(self):
-        if is_ball_our_side():
+        if is_ball_our_side() and not (our_player_is_closest() and no_enemy_around_ball()):
             return SimpleAutoPlayState.NORMAL_DEFENSE
         else:
             return SimpleAutoPlayState.NORMAL_OFFENSE

--- a/ai/STA/Strategy/penalty_offense.py
+++ b/ai/STA/Strategy/penalty_offense.py
@@ -9,6 +9,7 @@ from ai.STA.Tactic.goalkeeper import GoalKeeper
 from ai.states.game_state import GameState
 from Util.geometry import Area
 
+
 class PenaltyOffense(TeamGoToPosition):
     def __init__(self, game_state):
         super().__init__(game_state)
@@ -35,3 +36,15 @@ class PenaltyOffense(TeamGoToPosition):
         self.create_node(Role.GOALKEEPER, GoalKeeper(game_state, goalkeeper, penalty_kick=True))
 
         self.assign_tactics(role_to_positions)
+
+    @classmethod
+    def required_roles(cls):
+        return [Role.GOALKEEPER,
+                Role.FIRST_ATTACK]
+
+    @classmethod
+    def optional_roles(cls):
+        return [Role.SECOND_ATTACK,
+                Role.MIDDLE,
+                Role.FIRST_DEFENCE,
+                Role.SECOND_DEFENCE]

--- a/ai/STA/Tactic/go_kick.py
+++ b/ai/STA/Tactic/go_kick.py
@@ -94,7 +94,7 @@ class GoKick(Tactic):
                 self.next_state = self.go_behind_ball
         position_behind_ball = self.get_destination_behind_ball(effective_ball_spacing)
 
-        if angle_behind > 70 and dist_from_ball<1000:
+        if angle_behind > 70 and dist_from_ball < 1000:
             cruise_speed = 1 + ball_speed/1000
         else:
             cruise_speed = 3

--- a/ai/STA/Tactic/go_kick.py
+++ b/ai/STA/Tactic/go_kick.py
@@ -94,8 +94,7 @@ class GoKick(Tactic):
                 self.next_state = self.go_behind_ball
         position_behind_ball = self.get_destination_behind_ball(effective_ball_spacing)
 
-
-        if (angle_behind > 70) and (dist_from_ball<1000):
+        if angle_behind > 70 and dist_from_ball<1000:
             cruise_speed = 1 + ball_speed/1000
         else:
             cruise_speed = 3
@@ -211,7 +210,7 @@ class GoKick(Tactic):
 
         if not self.is_debug:
             return []
-          
+
         angle = None
         additional_dbg = []
         if self.current_state == self.go_behind_ball:


### PR DESCRIPTION
Previously, the autoplay directly switch from offensive to a defensive strategy when the ball was immobile and was our half of the field. The problem is that sometime we have a robot super close to the ball and no enemy near it, thus we don't to switch to a defensive strategy immediately.
I added  a check that we can stay in offensive if and only if we have the closest robot to the ball and no enemy robot near it.