### PR TITLE
Add outside forbidden zone

### DIFF
--- a/Debug/debug_command_factory.py
+++ b/Debug/debug_command_factory.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple, List
 
 from Engine.Controller.robot import Robot
 from Util import Pose, Position
-from Util.geometry import Area
+from Util.area import Area
 from Util.path import Path
 from Util.role import Role
 from ai.GameDomainObjects.player import Player

--- a/Util/area.py
+++ b/Util/area.py
@@ -1,40 +1,135 @@
-# Under MIT License, see LICENSE.txt
-import math as m
+from typing import Union
+
+from Util.geometry import Position, Pose, Line, intersection_between_segments, intersection_between_line_and_segment, \
+    closest_point_on_segment
 
 
-# Question
-from Util import Position
+class Area:
+    def __init__(self, a, b):
+        neg_x, pos_x = min(a.x, b.x), max(a.x, b.x)
+        neg_y, pos_y = min(a.y, b.y), max(a.y, b.y)
+        self.upper_left = Position(neg_x, pos_y)
+        self.upper_right = Position(pos_x, pos_y)
+        self.lower_right = Position(pos_x, neg_y)
+        self.lower_left = Position(neg_x, neg_y)
+
+    def point_inside(self, p: Position) -> bool:
+        return self.left <= p.x <= self.right and \
+               self.bottom <= p.y <= self.top
+
+    def __str__(self):
+        return f'Area(top={self.top}, bottom={self.bottom}, right={self.right}, left={self.left})'
+
+    def __contains__(self, item: Union[Pose, Position]):
+        if type(item) is Pose:
+            return self.point_inside(item.position)
+        elif type(item) is Position:
+            return self.point_inside(item)
+        else:
+            raise ValueError('You can only test if a position or a pose is contained inside the area.')
+
+    def intersect(self, seg: Line):
+        assert isinstance(seg, Line)
+        if self.point_inside(seg.p1) and self.point_inside(seg.p2):
+            return []
+
+        inters = []
+        for segment in self.segments:
+            inter = intersection_between_segments(segment.p1, segment.p2, seg.p1, seg.p2)
+            if inter is not None:
+                inters.append(inter)
+        return inters
+
+    def intersect_with_line(self, line: Line):
+        assert isinstance(line, Line)
+
+        inters = []
+        for segment in self.segments:
+            inter = intersection_between_line_and_segment(segment.p1, segment.p2, line.p1, line.p2)
+            if inter is not None:
+                inters.append(inter)
+        return inters
+
+    def closest_border_point(self, p: Position):
+        closest_on_borders = None
+        for segment in self.segments:
+            closest_on_segment = closest_point_on_segment(p, segment.p1, segment.p2)
+            if closest_on_borders is None or (closest_on_segment - p).norm < (closest_on_borders - p).norm:
+                closest_on_borders = closest_on_segment
+        return closest_on_borders
+
+    @property
+    def segments(self):
+        return [Line(self.upper_left,  self.upper_right),
+                Line(self.upper_right, self.lower_right),
+                Line(self.lower_right, self.lower_left),
+                Line(self.lower_left,  self.upper_left)]
+
+    @property
+    def center(self):
+        return self.lower_left + Position(self.width / 2, self.height / 2)
+
+    @property
+    def width(self):
+        return self.right - self.left
+
+    @property
+    def height(self):
+        return self.top - self.bottom
+
+    @property
+    def top(self):
+        return self.upper_left.y
+
+    @property
+    def bottom(self):
+        return self.lower_right.y
+
+    @property
+    def left(self):
+        return self.upper_left.x
+
+    @property
+    def right(self):
+        return self.lower_right.x
+
+    @classmethod
+    def pad(cls, area, padding=0):
+        return cls.from_limits(area.top + padding, area.bottom - padding,
+                               area.right + padding, area.left - padding)
+
+    @classmethod
+    def from_limits(cls, top, bottom, right, left):
+        return cls(Position(left, top), Position(right, bottom))
+
+    @classmethod
+    def flip_x(cls, area):
+        return cls.from_limits(area.top, area.bottom, -area.left, -area.right)
+
+    @classmethod
+    def from_4_point(cls, p1, p2, p3, p4):
+        top = max(p1.y, p2.y, p3.y, p4.y)
+        bot = min(p1.y, p2.y, p3.y, p4.y)
+        right = max(p1.x, p2.x, p3.x, p4.x)
+        left = min(p1.x, p2.x, p3.x, p4.x)
+        return cls.from_limits(top, bot, right, left)
 
 
-def is_inside_circle(position, center, radius):
-    # Parameters assertions
-    assert isinstance(position, Position)
-    assert isinstance(center, Position)
-    assert isinstance(radius, (int, float))
-    assert radius >= 0
+class ForbiddenZone(Area):
+    def __init__(self, a, b, inside_forbidden=True):
+        super(ForbiddenZone, self).__init__(a, b)
+        self.inside_forbidden = inside_forbidden
 
-    return (position - center).norm < radius
+    def __contains__(self, item: Union[Pose, Position]):
+        if type(item) is Pose:
+            return self.point_inside(item.position)
+        elif type(item) is Position:
+            return self.point_inside(item)
+        else:
+            raise ValueError('You can only test if a position or a pose is contained inside the area.')
 
-
-def is_outside_circle(position, center, radius):
-    return not is_inside_circle(position, center, radius)
-
-
-def stay_inside_circle(position, center, radius):
-    # Parameters assertions
-    if is_inside_circle(position, center, radius):
-        return Position(position.x, position.y)
-    pos_angle = (position - center).angle
-    pos_x = radius * m.cos(pos_angle) + center.x
-    pos_y = radius * m.sin(pos_angle) + center.y
-    return Position(pos_x, pos_y)
-
-
-def stay_outside_circle(position, center, radius):
-    # Parameters assertions
-    if is_outside_circle(position, center, radius):
-        return Position(position.x, position.y)
-    pos_angle = (position - center).angle
-    pos_x = radius * m.cos(pos_angle) + center.x
-    pos_y = radius * m.sin(pos_angle) + center.y
-    return Position(pos_x, pos_y)
+    def point_inside(self, p: Position) -> bool:
+        is_inside = self.left <= p.x <= self.right and \
+                   self.bottom <= p.y <= self.top
+        # If inside_forbidden is false, the outside is the forbidden zone
+        return self.inside_forbidden == is_inside

--- a/Util/geometry.py
+++ b/Util/geometry.py
@@ -9,7 +9,7 @@ Position = Util.position.Position
 import Util.pose as pose
 Pose = pose.Pose
 
-from typing import cast, Sequence, List, Union, Optional
+from typing import cast, Sequence, List, Optional
 
 
 class Line:
@@ -27,117 +27,6 @@ class Line:
     @property
     def length(self):
         return (self.p2 - self.p1).norm
-
-
-class Area:
-    def __init__(self, a, b):
-        neg_x, pos_x = min(a.x, b.x), max(a.x, b.x)
-        neg_y, pos_y = min(a.y, b.y), max(a.y, b.y)
-        self.upper_left = Position(neg_x, pos_y)
-        self.upper_right = Position(pos_x, pos_y)
-        self.lower_right = Position(pos_x, neg_y)
-        self.lower_left = Position(neg_x, neg_y)
-
-    def point_inside(self, p: Position) -> bool:
-        return self.left <= p.x <= self.right and \
-               self.bottom <= p.y <= self.top
-
-    def __str__(self):
-        return f'Area(top={self.top}, bottom={self.bottom}, right={self.right}, left={self.left})'
-
-    def __contains__(self, item: Union[Pose, Position]):
-        if type(item) is Pose:
-            return self.point_inside(item.position)
-        elif type(item) is Position:
-            return self.point_inside(item)
-        else:
-            raise ValueError('You can only test if a position or a pose is contained inside the area.')
-
-    def intersect(self, seg: Line):
-        assert isinstance(seg, Line)
-        if self.point_inside(seg.p1) and self.point_inside(seg.p2):
-            return []
-
-        inters = []
-        for segment in self.segments:
-            inter = intersection_between_segments(segment.p1, segment.p2, seg.p1, seg.p2)
-            if inter is not None:
-                inters.append(inter)
-        return inters
-
-    def intersect_with_line(self, line: Line):
-        assert isinstance(line, Line)
-
-        inters = []
-        for segment in self.segments:
-            inter = intersection_between_line_and_segment(segment.p1, segment.p2, line.p1, line.p2)
-            if inter is not None:
-                inters.append(inter)
-        return inters
-
-    def closest_border_point(self, p: Position):
-        closest_on_borders = None
-        for segment in self.segments:
-            closest_on_segment = closest_point_on_segment(p, segment.p1, segment.p2)
-            if closest_on_borders is None or (closest_on_segment - p).norm < (closest_on_borders - p).norm:
-                closest_on_borders = closest_on_segment
-        return closest_on_borders
-
-    @property
-    def segments(self):
-        return [Line(self.upper_left,  self.upper_right),
-                Line(self.upper_right, self.lower_right),
-                Line(self.lower_right, self.lower_left),
-                Line(self.lower_left,  self.upper_left)]
-
-    @property
-    def center(self):
-        return self.lower_left + Position(self.width / 2, self.height / 2)
-
-    @property
-    def width(self):
-        return self.right - self.left
-
-    @property
-    def height(self):
-        return self.top - self.bottom
-
-    @property
-    def top(self):
-        return self.upper_left.y
-
-    @property
-    def bottom(self):
-        return self.lower_right.y
-
-    @property
-    def left(self):
-        return self.upper_left.x
-
-    @property
-    def right(self):
-        return self.lower_right.x
-
-    @classmethod
-    def pad(cls, area, padding=0):
-        return Area.from_limits(area.top + padding, area.bottom - padding,
-                                area.right + padding, area.left - padding)
-
-    @classmethod
-    def from_limits(cls, top, bottom, right, left):
-        return cls(Position(left, top), Position(right, bottom))
-
-    @classmethod
-    def flip_x(cls, area):
-        return Area.from_limits(area.top, area.bottom, -area.left, -area.right)
-
-    @classmethod
-    def from_4_point(cls, p1, p2, p3, p4):
-        top = max(p1.y, p2.y, p3.y, p4.y)
-        bot = min(p1.y, p2.y, p3.y, p4.y)
-        right = max(p1.x, p2.x, p3.x, p4.x)
-        left = min(p1.x, p2.x, p3.x, p4.x)
-        return Area.from_limits(top, bot, right, left)
 
 
 def find_bisector_of_triangle(c, a, b):
@@ -290,3 +179,37 @@ def distance_from_points(point: Position, points: Sequence[Position]) -> List[fl
 
 def random_direction():
     return normalize(Position.from_array(np.random.randn(2)))
+
+
+def is_inside_circle(position, center, radius):
+    # Parameters assertions
+    assert isinstance(position, Position)
+    assert isinstance(center, Position)
+    assert isinstance(radius, (int, float))
+    assert radius >= 0
+
+    return (position - center).norm < radius
+
+
+def is_outside_circle(position, center, radius):
+    return not is_inside_circle(position, center, radius)
+
+
+def stay_inside_circle(position, center, radius):
+    # Parameters assertions
+    if is_inside_circle(position, center, radius):
+        return Position(position.x, position.y)
+    pos_angle = (position - center).angle
+    pos_x = radius * m.cos(pos_angle) + center.x
+    pos_y = radius * m.sin(pos_angle) + center.y
+    return Position(pos_x, pos_y)
+
+
+def stay_outside_circle(position, center, radius):
+    # Parameters assertions
+    if is_outside_circle(position, center, radius):
+        return Position(position.x, position.y)
+    pos_angle = (position - center).angle
+    pos_x = radius * m.cos(pos_angle) + center.x
+    pos_y = radius * m.sin(pos_angle) + center.y
+    return Position(pos_x, pos_y)

--- a/ai/STA/Strategy/penalty_offense.py
+++ b/ai/STA/Strategy/penalty_offense.py
@@ -7,7 +7,8 @@ from ai.STA.Strategy.team_go_to_position import TeamGoToPosition
 from ai.STA.Tactic.go_kick import GoKick
 from ai.STA.Tactic.goalkeeper import GoalKeeper
 from ai.states.game_state import GameState
-from Util.geometry import Area
+from Util.area import Area
+
 
 class PenaltyOffense(TeamGoToPosition):
     def __init__(self, game_state):

--- a/ai/STA/Tactic/goalkeeper.py
+++ b/ai/STA/Tactic/goalkeeper.py
@@ -17,7 +17,8 @@ from Util import Pose, Position
 from Util.ai_command import MoveTo, Idle, CmdBuilder
 from Util.constant import ROBOT_RADIUS, KEEPOUT_DISTANCE_FROM_GOAL, ROBOT_DIAMETER
 from Util.geometry import intersection_line_and_circle, intersection_between_lines, \
-    closest_point_on_segment, find_bisector_of_triangle, Area, Line, clamp
+    closest_point_on_segment, find_bisector_of_triangle, Line, clamp
+from Util.area import Area
 from ai.GameDomainObjects import Player
 from ai.STA.Tactic.go_kick import GRAB_BALL_SPACING, GoKick
 from ai.STA.Tactic.tactic import Tactic

--- a/ai/STA/Tactic/position_for_pass.py
+++ b/ai/STA/Tactic/position_for_pass.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 
 from Util import Pose, Position
 from Util.ai_command import MoveTo
-from Util.geometry import Area, Line, clamp, normalize
+from Util.geometry import Line, clamp, normalize
+from Util.area import Area
 from Util.role import Role
 from ai.GameDomainObjects import Player
 from ai.STA.Tactic.tactic import Tactic

--- a/ai/STA/Tactic/stay_away_from_ball.py
+++ b/ai/STA/Tactic/stay_away_from_ball.py
@@ -3,9 +3,9 @@ from typing import List, Optional
 
 from Util import Pose
 from Util.ai_command import MoveTo
-from Util.area import stay_outside_circle
 from Util.constant import KEEPOUT_DISTANCE_FROM_BALL
-from Util.geometry import Area
+from Util.geometry import stay_outside_circle
+from Util.area import Area
 from ai.GameDomainObjects import Player
 from ai.STA.Tactic.tactic import Tactic
 from ai.states.game_state import GameState

--- a/tests/Util/test_geometry.py
+++ b/tests/Util/test_geometry.py
@@ -7,8 +7,8 @@ import pytest
 
 from Util import Position
 from Util.geometry import closest_point_on_line, closest_point_on_segment, closest_point_to_points, \
-    intersection_between_lines, find_bisector_of_triangle, angle_between_three_points, Area, \
-    random_direction, intersection_between_segments
+    intersection_between_lines, find_bisector_of_triangle, angle_between_three_points, random_direction, intersection_between_segments
+from Util.area import Area
 from Util.geometry import compare_angle, wrap_to_pi, perpendicular, normalize, are_close, rotate
 
 


### PR DESCRIPTION
Robots should try to go outside the field's borders. To prevent it, we add a forbidden zone which around the borders. However, the previous implementation was inefficient since it used 4 forbidden zones to represent the border. This is because in the old implementation a forbidden zone was a rectangle where the robot can not go in, so to represent the inverse (i.e. a rectangle where you can not go out)  we needed one forbidden zone for each segment of the rectangle.

So now a forbidden zone can means a rectangle that you cannot enter or a rectangle that you cannot leave.