### PR TITLE
less bad defense wall

### DIFF
--- a/Util/geometry.py
+++ b/Util/geometry.py
@@ -213,3 +213,7 @@ def stay_outside_circle(position, center, radius):
     pos_x = radius * m.cos(pos_angle) + center.x
     pos_y = radius * m.sin(pos_angle) + center.y
     return Position(pos_x, pos_y)
+
+
+def points_on_same_vert_or_hori_line(a: Position, b: Position):
+    return abs(a.x - b.x) < 0.1 or abs(a.y - b.y) < 0.1

--- a/ai/STA/Strategy/defense_wall.py
+++ b/ai/STA/Strategy/defense_wall.py
@@ -47,7 +47,8 @@ class DefenseWall(Strategy):
 
         for role, player in self.assigned_roles.items():
             if role == Role.GOALKEEPER:
-                self.create_node(Role.GOALKEEPER, GoalKeeper(self.game_state, player))
+                pass
+                #self.create_node(Role.GOALKEEPER, GoalKeeper(self.game_state, player))
             elif player in self.attackers:
                 node_position_pass = self.create_node(role, PositionForPass(self.game_state,
                                                                             player,
@@ -126,7 +127,7 @@ class DefenseWall(Strategy):
                 node_wait_for_pass.connect_to(node_go_kick, when=player_has_received_ball)
                 node_go_kick.connect_to(node_align_to_defense_wall, when=player_has_kicked)
                 node_position_pass.connect_to(node_wait_for_pass, when=player_is_receiving_pass)
-                node_position_pass.connect_to(node_align_to_defense_wall, when=player_is_not_receiving_pass)
+                # node_position_pass.connect_to(node_align_to_defense_wall, when=player_is_not_receiving_pass)
 
 
     @classmethod
@@ -168,6 +169,9 @@ class DefenseWall(Strategy):
         else:
             return False
 
+    def _remove_not_available_roles(self, unfiltered_roles):
+        return [r for r in unfiltered_roles if r in self.assigned_roles.keys()]
+
     def _dispatch_player(self):
 
         if not self.can_kick and self.multiple_cover:
@@ -175,6 +179,8 @@ class DefenseWall(Strategy):
             self.cover_role += [Role.SECOND_ATTACK]
         if not self.can_kick and not self.multiple_cover:
             self.defensive_role += [Role.FIRST_ATTACK, Role.SECOND_ATTACK]
+        self.defensive_role = self._remove_not_available_roles(self.defensive_role)
+        self.cover_role = self._remove_not_available_roles(self.cover_role)
 
         self.robots_in_wall_formation = [p for r, p in self.assigned_roles.items() if r in self.defensive_role]
         self.robots_in_cover_formation = [p for r, p in self.assigned_roles.items() if r in self.cover_role]

--- a/ai/STA/Strategy/defense_wall.py
+++ b/ai/STA/Strategy/defense_wall.py
@@ -47,8 +47,7 @@ class DefenseWall(Strategy):
 
         for role, player in self.assigned_roles.items():
             if role == Role.GOALKEEPER:
-                pass
-                #self.create_node(Role.GOALKEEPER, GoalKeeper(self.game_state, player))
+                self.create_node(Role.GOALKEEPER, GoalKeeper(self.game_state, player))
             elif player in self.attackers:
                 node_position_pass = self.create_node(role, PositionForPass(self.game_state,
                                                                             player,

--- a/ai/STA/Strategy/defense_wall_no_kick.py
+++ b/ai/STA/Strategy/defense_wall_no_kick.py
@@ -6,6 +6,7 @@ from ai.states.game_state import GameState
 
 BALL_HAS_MOVE_TOO_MUCH = 300
 
+
 # noinspection
 class DefenseWallNoKick(DefenseWall):
     def __init__(self, game_state: GameState):

--- a/ai/STA/Tactic/align_to_defense_wall.py
+++ b/ai/STA/Tactic/align_to_defense_wall.py
@@ -5,7 +5,8 @@ from typing import List, Optional
 from Debug.debug_command_factory import DebugCommandFactory
 from Util import Pose
 from Util.ai_command import Idle, MoveTo
-from Util.constant import ROBOT_RADIUS, ROBOT_DIAMETER, KEEPOUT_DISTANCE_FROM_BALL
+from Util.area import Area
+from Util.constant import ROBOT_RADIUS, ROBOT_DIAMETER, KEEPOUT_DISTANCE_FROM_BALL, REASONABLE_OFFSET
 from Util.geometry import perpendicular, normalize, find_bisector_of_triangle, angle_between_three_points, Line, \
     intersection_line_and_circle
 from Util.role import Role
@@ -78,24 +79,61 @@ class AlignToDefenseWall(Tactic):
         self.bisect_inter = find_bisector_of_triangle(self.object_to_block.position, goal_line.p1, goal_line.p2)
         vec_object_to_goal_line_bisect = self.bisect_inter - self.object_to_block.position
 
-        # The penalty zone used to be a circle and thus really easy to handle, but now it's a rectangle...
-        # It easier to first create the smallest circle that fit the rectangle.
-        min_radius_over_penality_zone = ROBOT_RADIUS + \
-            (self.game_state.field.our_goal_area.upper_left - self.game_state.field.our_goal).norm
-        object_to_block_to_center_formation_dist = min(
-            vec_object_to_goal_line_bisect.norm - min_radius_over_penality_zone,
-            object_to_center_formation_dist)
 
-        self.center_formation = object_to_block_to_center_formation_dist * normalize(
-            vec_object_to_goal_line_bisect) + self.object_to_block.position
+        # # If the object is far away from the goal, we use object_to_center_formation_dist,
+        # # otherwise we touch the circle that fit the rectangle (goal area).
+        # # object_to_block_to_center_formation_dist = min(
+        # #     vec_object_to_goal_line_bisect.norm - min_radius_over_penality_zone,
+        # #     object_to_center_formation_dist)
+        object_to_block_to_center_formation_dist = object_to_center_formation_dist
+
+        self.center_formation = object_to_block_to_center_formation_dist * normalize(vec_object_to_goal_line_bisect) \
+                                + self.object_to_block.position
 
         if self.stay_away_from_ball:
             if (self.game_state.ball_position - self.center_formation).norm < KEEPOUT_DISTANCE_FROM_BALL:
                 self.center_formation = self._closest_point_away_from_ball()
 
-        half_wall_segment = 0.5 * wall_segment_length * perpendicular(normalize(vec_object_to_goal_line_bisect))
+        dir_wall_segment = perpendicular(normalize(vec_object_to_goal_line_bisect))
+
+        half_wall_segment = 0.5 * wall_segment_length * dir_wall_segment
         self.wall_segment = Line(self.center_formation + half_wall_segment,
                                  self.center_formation - half_wall_segment)
+
+        # If wall segment is inside the goal area,
+        # we must recompute a new wall segment which is on the border of the goal area
+        goal_area = Area.pad(self.game_state.field.our_goal_forbidden_area, 10)
+        if self.object_to_block.position not in goal_area and \
+            (self.center_formation in goal_area
+            or self.wall_segment.p1 in goal_area
+            or self.wall_segment.p2 in goal_area):
+
+            line_a = Line(self.object_to_block.position, self.game_state.field.our_goal_line.p1)
+            line_b = Line(self.object_to_block.position, self.game_state.field.our_goal_line.p2)
+            inter_a = goal_area.intersect(line_a)
+            inter_b = goal_area.intersect(line_b)
+            if len(inter_a) != 1 or len(inter_b) != 1:
+                self.logger.error(f"This is impossible, lines should touch goal area only once: {inter_a} {inter_b}")
+                return
+            inter_a, inter_b = inter_a[0], inter_b[0]
+            # There are three cases for a wall_segment inside the goal area:
+            # A) wall_segment touch left and top/bot part of the area
+            if abs(inter_a.x - inter_b.x) > 1 and abs(inter_a.y - inter_b.y) > 1:
+                print('a', inter_a, inter_b)
+                # The penalty zone used to be a circle and thus really easy to handle, but now it's a rectangle...
+                # It easier to first create the smallest circle that fit the rectangle.
+                min_radius_over_penality_zone = (self.game_state.field.our_goal_forbidden_area.upper_left - self.game_state.field.our_goal).norm
+                self.center_formation = self.game_state.field.our_goal \
+                                        - min_radius_over_penality_zone * normalize(vec_object_to_goal_line_bisect)
+            else:  # C) wall_segment touch left part of the area or  top/bot part of the area
+                print('c')
+                # The wall is simply the intersection between line_a/line_b and the goal area
+                self.center_formation = (inter_a + inter_b) / 2
+                dir_wall_segment = normalize(inter_a - inter_b)
+
+            half_wall_segment = 0.5 * wall_segment_length * dir_wall_segment
+            self.wall_segment = Line(self.center_formation + half_wall_segment,
+                                     self.center_formation - half_wall_segment)
 
     def position_on_wall_segment(self):
         idx = self.player_number_in_formation
@@ -111,10 +149,10 @@ class AlignToDefenseWall(Tactic):
                 DebugCommandFactory().line(self.center_formation,
                                            self.bisect_inter,
                                            timeout=0.1),
-                DebugCommandFactory().line(self.game_state.ball_position,
+                DebugCommandFactory().line(self.object_to_block.position,
                                            self.game_state.field.our_goal_line.p1,
                                            timeout=0.1),
-                DebugCommandFactory().line(self.game_state.ball_position,
+                DebugCommandFactory().line(self.object_to_block.position,
                                            self.game_state.field.our_goal_line.p2,
                                            timeout=0.1)
                 ]
@@ -128,7 +166,12 @@ class AlignToDefenseWall(Tactic):
                 and self._no_enemy_around_ball():
             self.next_state = self.go_kick
         dest = self.position_on_wall_segment()
-        dest_orientation = (self.object_to_block.position - dest).angle
+
+        if self.wall_segment.length > 0:
+            # Look forward, perpendicular to the wall
+            dest_orientation = (-perpendicular(self.wall_segment.direction)).angle
+        else:
+            dest_orientation = (self.object_to_block.position - dest).angle
         return MoveTo(Pose(dest,
                            dest_orientation), cruise_speed=self.cruise_speed)
 

--- a/ai/STA/Tactic/goalkeeper.py
+++ b/ai/STA/Tactic/goalkeeper.py
@@ -190,14 +190,7 @@ class GoalKeeper(Tactic):
                (ball_speed > self.MOVING_BALL_VELOCITY and upper_angle <= self.game_state.ball.velocity.angle <= lower_angle)
 
     def _is_ball_safe_to_kick(self):
-        # Since defender can not kick the ball while inside the goal there are position where the ball is unreachable
-        # The goalee must leave the goal area and kick the ball
-        goal_area = self.game_state.field.our_goal_area
-        width = KEEPOUT_DISTANCE_FROM_GOAL + ROBOT_DIAMETER
-        area_in_front_of_goal = Area.from_limits(goal_area.top, goal_area.bottom,
-                                                 goal_area.left, goal_area.left - width)
-        return self.game_state.field.is_ball_in_our_goal_area() or \
-               area_in_front_of_goal.point_inside(self.game_state.ball.position) and self._no_enemy_around_ball()
+        return self.game_state.field.is_ball_in_our_goal_area()
 
     def _best_target_into_goal(self):
         if 0 < len(self.game_state.enemy_team.available_players):


### PR DESCRIPTION
The defense wall normally can not go closer to the goal area than the smallest circle that fit the goal area. 
There are various locations where the ball is outside the goal area, but not protected by the defense wall.
 - Now the defense wall will go along the side of the goal area. There are two cases: either the robots can go along a vertical/horizontal line or they follow the smallest circle that fit the goal area
 - Goalkeeper does not need to clear the ball if it's outside the goal area
 - Fix a bug in defense wall where the player would go back and forth between position for pass and align to defense wall
 - Fix bug where not assigned role would be part of the defense wall

The code still need a bit of refactoring.
